### PR TITLE
basic implementation of serial response

### DIFF
--- a/long_sdrt.html
+++ b/long_sdrt.html
@@ -5,6 +5,7 @@
     <script src="jspsych.js"></script>
     <script src="plugins/jspsych-instructions.js"></script>
     <script src="plugins/jspsych-audio-button-response.js"></script>
+    <script src="plugins/jspsych-audio-keyboard-response.js"></script>
     <script src="plugins/jspsych-html-button-response.js"></script>
     <script src="poldrack_plugins/jspsych-single-stim-button.js"></script>
     <script src="plugins/jspsych-survey-text.js"></script>
@@ -212,23 +213,45 @@ var main_loop = {
 timeline.push(visual_melody_instructions_block_2);
 
 var twoblock = {
-    timeline: [
-        {
-            type: 'audio-button-response',
-            stimulus: jsPsych.timelineVariable('melody'),
-            choices: ['LISTEN'],
-            prompt: "This is where I want my audio to play and they just listen with no response",
-        },
-        {
-            type: 'html-button-response',
-  	    stimulus: "<p>STIMULI</p>",
-            choices: ['This would be a grid that collects multiple responses like trial examples before'],
-            prompt: "<p>This scren will collect their responses in serial order with RT</p>" 
-        }
-    ],
-    timeline_variables: [
-	{ melody: 'stimuli/long/c-le.mp3' },
-    ]
+  timeline: [
+    {
+      type: 'audio-keyboard-response',
+      stimulus: jsPsych.timelineVariable('melody'),
+      choices: jsPsych.NO_KEYS,
+      trial_ends_after_audio: true,
+      prompt: "Listen.",
+    },
+    {
+      type: 'html-button-response',
+      stimulus: "<p>Which tone was played first after the cadence?</p>",
+      choices: ['Do |  1', 'Ra | b2', 'Re | 2', 'Me | b3', 'Mi | 3', 'Fa | 4', 'Fi | #4', 'Sol | 5', 'Le | b6', 'La | 6', 'Te | b7', 'Ti | 7', 'Do | 1'],
+      data: {
+        response_sequence: 1,
+        melody: jsPsych.timelineVariable('melody')
+      }
+    },
+    {
+      type: 'html-button-response',
+      stimulus: "<p>Which tone was played second after the cadence?</p>",
+      choices: ['Do |  1', 'Ra | b2', 'Re | 2', 'Me | b3', 'Mi | 3', 'Fa | 4', 'Fi | #4', 'Sol | 5', 'Le | b6', 'La | 6', 'Te | b7', 'Ti | 7', 'Do | 1'],
+      data: {
+        response_sequence: 2,
+        melody: jsPsych.timelineVariable('melody')
+      }
+    },
+    {
+      type: 'html-button-response',
+      stimulus: "<p>Which tone was played third after the cadence?</p>",
+      choices: ['Do |  1', 'Ra | b2', 'Re | 2', 'Me | b3', 'Mi | 3', 'Fa | 4', 'Fi | #4', 'Sol | 5', 'Le | b6', 'La | 6', 'Te | b7', 'Ti | 7', 'Do | 1'],
+      data: {
+        response_sequence: 3,
+        melody: jsPsych.timelineVariable('melody')
+      }
+    }
+  ],
+  timeline_variables: [
+    { melody: 'stimuli/long/c-le.mp3' },
+  ]
 }
 
 timeline.push(twoblock)

--- a/plugins/jspsych-audio-keyboard-response.js
+++ b/plugins/jspsych-audio-keyboard-response.js
@@ -1,0 +1,185 @@
+/**
+ * jspsych-audio-keyboard-response
+ * Josh de Leeuw
+ *
+ * plugin for playing an audio file and getting a keyboard response
+ *
+ * documentation: docs.jspsych.org
+ *
+ **/
+
+jsPsych.plugins["audio-keyboard-response"] = (function() {
+
+  var plugin = {};
+
+  jsPsych.pluginAPI.registerPreload('audio-keyboard-response', 'stimulus', 'audio');
+
+  plugin.info = {
+    name: 'audio-keyboard-response',
+    description: '',
+    parameters: {
+      stimulus: {
+        type: jsPsych.plugins.parameterType.AUDIO,
+        pretty_name: 'Stimulus',
+        default: undefined,
+        description: 'The audio to be played.'
+      },
+      choices: {
+        type: jsPsych.plugins.parameterType.KEYCODE,
+        pretty_name: 'Choices',
+        array: true,
+        default: jsPsych.ALL_KEYS,
+        description: 'The keys the subject is allowed to press to respond to the stimulus.'
+      },
+      prompt: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Prompt',
+        default: null,
+        description: 'Any content here will be displayed below the stimulus.'
+      },
+      trial_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Trial duration',
+        default: null,
+        description: 'The maximum duration to wait for a response.'
+      },
+      response_ends_trial: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Response ends trial',
+        default: true,
+        description: 'If true, the trial will end when user makes a response.'
+      },
+      trial_ends_after_audio: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Trial ends after audio',
+        default: false,
+        description: 'If true, then the trial will end as soon as the audio file finishes playing.'
+      },
+    }
+  }
+
+  plugin.trial = function(display_element, trial) {
+
+    // setup stimulus
+    var context = jsPsych.pluginAPI.audioContext();
+    if(context !== null){
+      var source = context.createBufferSource();
+      source.buffer = jsPsych.pluginAPI.getAudioBuffer(trial.stimulus);
+      source.connect(context.destination);
+    } else {
+      var audio = jsPsych.pluginAPI.getAudioBuffer(trial.stimulus);
+      audio.currentTime = 0;
+    }
+
+    // set up end event if trial needs it
+
+    if(trial.trial_ends_after_audio){
+      if(context !== null){
+        source.onended = function() {
+          end_trial();
+        }
+      } else {
+        audio.addEventListener('ended', end_trial);
+      }
+    }
+
+    // show prompt if there is one
+    if (trial.prompt !== null) {
+      display_element.innerHTML = trial.prompt;
+    }
+
+    // store response
+    var response = {
+      rt: null,
+      key: null
+    };
+
+    // function to end trial when it is time
+    function end_trial() {
+
+      // kill any remaining setTimeout handlers
+      jsPsych.pluginAPI.clearAllTimeouts();
+
+      // stop the audio file if it is playing
+      // remove end event listeners if they exist
+      if(context !== null){
+        source.stop();
+        source.onended = function() { }
+      } else {
+        audio.pause();
+        audio.removeEventListener('ended', end_trial);
+      }
+
+      // kill keyboard listeners
+      jsPsych.pluginAPI.cancelAllKeyboardResponses();
+
+      // gather the data to store for the trial
+      if(context !== null && response.rt !== null){
+        response.rt = Math.round(response.rt * 1000);
+      }
+      var trial_data = {
+        "rt": response.rt,
+        "stimulus": trial.stimulus,
+        "key_press": response.key
+      };
+
+      // clear the display
+      display_element.innerHTML = '';
+
+      // move on to the next trial
+      jsPsych.finishTrial(trial_data);
+    };
+
+    // function to handle responses by the subject
+    var after_response = function(info) {
+
+      // only record the first response
+      if (response.key == null) {
+        response = info;
+      }
+
+      if (trial.response_ends_trial) {
+        end_trial();
+      }
+    };
+
+    // start audio
+    if(context !== null){
+      startTime = context.currentTime;
+      source.start(startTime);
+    } else {
+      audio.play();
+    }
+
+    // start the response listener
+    if(context !== null) {
+      var keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
+        callback_function: after_response,
+        valid_responses: trial.choices,
+        rt_method: 'audio',
+        persist: false,
+        allow_held_key: false,
+        audio_context: context,
+        audio_context_start_time: startTime
+      });
+    } else {
+      var keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
+        callback_function: after_response,
+        valid_responses: trial.choices,
+        rt_method: 'performance',
+        persist: false,
+        allow_held_key: false
+      });
+    }
+
+    // end trial if time limit is set
+    if (trial.trial_duration !== null) {
+      jsPsych.pluginAPI.setTimeout(function() {
+        end_trial();
+      }, trial.trial_duration);
+    }
+
+  };
+
+  return plugin;
+})();


### PR DESCRIPTION
I made a couple changes:

1. Added the `audio-keyboard-response` plugin for the trial where you want subjects to listen with no response. You can set choices to jsPsych.NO_KEYS to prevent responses, and set trial_ends_after_audio to true to advance when the audio finishes.
2. Used `html-keyboard-response` to recreate the basic set of buttons. I added two properties to the `data` of the trial. One will store which melody played in that iteration of the timeline. The other stores which part of the sequence is being responded to.

I think this will work if you want a fixed number of responses for each melody. If the number of responses needs to change then there are ways to make this more dynamic, but it would add significant complexity to the code. So I thought I would check if this is sufficient first :)